### PR TITLE
Compile messages first

### DIFF
--- a/reflex/CMakeLists.txt
+++ b/reflex/CMakeLists.txt
@@ -29,3 +29,4 @@ add_executable(tf_broadcaster src/tf_broadcaster.cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(tf_broadcaster ${catkin_LIBRARIES})
+add_dependencies(tf_broadcaster ${catkin_EXPORTED_TARGETS})

--- a/reflex/launch/reflex_takktile.launch
+++ b/reflex/launch/reflex_takktile.launch
@@ -2,5 +2,5 @@
   <rosparam file="$(find reflex)/yaml/tf_geometry.yaml" command="load"/>
   <rosparam file="$(find reflex)/yaml/reflex_takktile.yaml" command="load"/>
   <include file="$(find reflex_driver)/launch/reflex_driver.launch"/>
-  <node name="reflex_takktile_hand" pkg="reflex" type="reflex_takktile_hand.py" output="screen" required="true" />  
+  <node name="reflex_takktile_hand" pkg="reflex" type="reflex_takktile_hand.py" output="screen"/>  
 </launch>

--- a/reflex_driver/CMakeLists.txt
+++ b/reflex_driver/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 catkin_package( CATKIN_DEPENDS roscpp reflex_msgs)
 
 add_library(reflex_hand reflex_hand.cpp)
+target_link_libraries(reflex_hand ${catkin_LIBRARIES})
 
 add_executable(reflex_driver_node reflex_driver_node.cpp)
 target_link_libraries(reflex_driver_node reflex_hand ${catkin_LIBRARIES})

--- a/reflex_driver/launch/reflex_driver.launch
+++ b/reflex_driver/launch/reflex_driver.launch
@@ -8,6 +8,6 @@
 	<rosparam file="$(find reflex_driver)/yaml/tactile_calibrate.yaml" command="load"/>
 
 	<node name="driver_node" pkg="reflex_driver" type="reflex_driver_node" output="screen" required="true">
-		<param name="network_interface" value="eth2"/>
+		<param name="network_interface" value="eth5"/>
 	</node>
 </launch>

--- a/reflex_driver/launch/reflex_driver.launch
+++ b/reflex_driver/launch/reflex_driver.launch
@@ -7,5 +7,7 @@
 	<rosparam file="$(find reflex_driver)/yaml/finger_calibrate.yaml" command="load"/>
 	<rosparam file="$(find reflex_driver)/yaml/tactile_calibrate.yaml" command="load"/>
 
-	<node name="driver_node" pkg="reflex_driver" type="reflex_driver_node" output="screen" required="true"/>
+	<node name="driver_node" pkg="reflex_driver" type="reflex_driver_node" output="screen" required="true">
+		<param name="network_interface" value="eth2"/>
+	</node>
 </launch>

--- a/reflex_visualizer/src/hand_visualizer.cpp
+++ b/reflex_visualizer/src/hand_visualizer.cpp
@@ -77,6 +77,7 @@ int main(int argc, char **argv)
   ros::Duration(2.0).sleep();
   reflex_msgs::Hand base_hand_state;
   for (int i=0; i<10; i++) {
+    ROS_INFO("Publishing state %d", i);
     pub.publish(base_hand_state);
     ros::Duration(0.5).sleep();
   }


### PR DESCRIPTION
Ensures that the message package is compiled before this one to avoid errors on the first build.