### PR TITLE
Add reflex_msgs as a required catkin_component

### DIFF
--- a/reflex_driver/CMakeLists.txt
+++ b/reflex_driver/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(reflex_driver)
-find_package(catkin REQUIRED COMPONENTS roscpp)
+find_package(catkin REQUIRED COMPONENTS roscpp reflex_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 catkin_package( CATKIN_DEPENDS roscpp reflex_msgs)
 


### PR DESCRIPTION
This change is needed to build the driver. Without this, catkin doesn't know where to find the Hand message file and produces an error.

I suspect that's why the fix at http://docs.righthandrobotics.com/doc:reflex:troubleshooting2 of building the msgs first works for some people (note: even that solution requires extra steps to work properly).

With this, one can pull the code and catkin_make without problems.