### PR TITLE
Tt2/driver node

### DIFF
--- a/reflex_driver2/src/reflex_driver_node.cpp
+++ b/reflex_driver2/src/reflex_driver_node.cpp
@@ -831,8 +831,16 @@ void move_fingers_in(const reflex_hand::ReflexHandState* const state) {
     motor_step = MOTOR_TO_JOINT_INVERTED[i] * calibration_dyn_increase[i];
     servo_pos.raw_positions[i] = state->dynamixel_angles_[i] + motor_step;
   }
-  
-  raw_pub.publish(servo_pos);
+
+  if (state->dynamixel_angles_[0] == 0 && state->dynamixel_angles_[1] == 0 && 
+      state->dynamixel_angles_[3] == 0 && state->dynamixel_angles_[4] == 0){
+    ROS_FATAL("ERROR! Encoder malfunction, prevented motor catastrophe, please check finger connections!");
+    g_done = true;
+  }
+  else{
+    raw_pub.publish(servo_pos);
+  }
+
 }
 
 

--- a/reflex_driver2/src/reflex_driver_node.cpp
+++ b/reflex_driver2/src/reflex_driver_node.cpp
@@ -832,15 +832,16 @@ void move_fingers_in(const reflex_hand::ReflexHandState* const state) {
     servo_pos.raw_positions[i] = state->dynamixel_angles_[i] + motor_step;
   }
 
-  if (state->dynamixel_angles_[0] == 0 && state->dynamixel_angles_[1] == 0 && 
-      state->dynamixel_angles_[3] == 0 && state->dynamixel_angles_[4] == 0){
-    ROS_FATAL("ERROR! Encoder malfunction, prevented motor catastrophe, please check finger connections!");
-    g_done = true;
+  if (state->dynamixel_angles_[0] == 0 || state->dynamixel_angles_[1] == 0 || 
+      state->dynamixel_angles_[2] == 0 || state->dynamixel_angles_[3] == 0){
+
+      ROS_FATAL("ERROR! Encoder malfunction, prevented motor catastrophe.\nPlease check finger connections!");
+      g_done = true;
+
   }
   else{
     raw_pub.publish(servo_pos);
   }
-
 }
 
 


### PR DESCRIPTION
Amends: Issue #36 - Requires future change to calibrate_fingers service
## Description of what your PR accomplishes: 
Prevents motors from over driving during calibration by detecting false Dynamixel angle values and shutting down servo position commands as a result.
## Why this approach? Any notable design decisions?
A necessary failsafe to prevent hardware damage given the chance of hardware disconnection of the fingers. Temporary fix for users until resolved completely.
Reviewers: @semendel @kevindalam